### PR TITLE
Add update system

### DIFF
--- a/nvidia_driver_script.sh
+++ b/nvidia_driver_script.sh
@@ -26,7 +26,7 @@ fi
 chmod +x $version.run
 
 printf "\n\n----------------------------------------------------------------\nInstalling dependencies...\n----------------------------------------------------------------\n"
-sudo dnf install kernel-devel kernel-headers gcc make dkms acpid libglvnd-glx libglvnd-opengl libglvnd-devel pkgconfig
+sudo dnf update -y && sudo dnf install kernel-devel kernel-headers gcc make dkms acpid libglvnd-glx libglvnd-opengl libglvnd-devel pkgconfig
 
 printf "\n\n----------------------------------------------------------------\nChecking noveau blacklisting...\n----------------------------------------------------------------\n"
 


### PR DESCRIPTION
For Fedora 29, for the first installation, it was very important to update the system, in particular the kernel.